### PR TITLE
implement redis::aio::ConnectionLike for deadpool::managed::Object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # unless the `rt_tokio_1` feature is enabled.
 tokio = { version = "1", features = ["sync"] }
 async-std = { version = "1", optional = true }
+redis = { version = "0.20.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -49,6 +50,7 @@ managed = ["async-trait"]
 unmanaged = []
 rt_tokio_1 = ["tokio/time"]
 rt_async-std_1 = ["async-std"]
+tc-redis-traits = ["redis", "redis/aio", "redis/tokio-comp"]
 
 [[bench]]
 name = "unmanaged"

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -184,6 +184,33 @@ impl<M: Manager> AsMut<M::Type> for Object<M> {
     }
 }
 
+#[cfg(feature = "tc-redis-traits")]
+impl<M> redis::aio::ConnectionLike for Object<M>
+where
+    M: Manager,
+    M::Type: redis::aio::ConnectionLike,
+{
+    fn req_packed_command<'a>(
+        &'a mut self,
+        cmd: &'a redis::Cmd,
+    ) -> redis::RedisFuture<'a, redis::Value> {
+        (**self).req_packed_command(cmd)
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a redis::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> redis::RedisFuture<'a, Vec<redis::Value>> {
+        (**self).req_packed_commands(cmd, offset, count)
+    }
+
+    fn get_db(&self) -> i64 {
+        (**self).get_db()
+    }
+}
+
 struct PoolInner<M: Manager> {
     manager: Box<M>,
     queue: std::sync::Mutex<VecDeque<M::Type>>,


### PR DESCRIPTION
## Problem

While `deadpool_redis::ConnectionWrapper` in the `deadpool-redis` crate implements `redis::aio::ConnectionLike`, the `ConnectionLike` trait is not implemented for `deadpool::managed::Object<deadpool_redis::Manager>` which is type of the instances actually returned from the `deadpool` connection pools.

This is not a problem if the `Object` instance is used immediately to call into the `redis` crate because Rust will use `Object`'s `std::ops::Deref` implementation to dereference the `Object` instance into the `ConnectionWrapper` which does implement `ConnectionLike`. 

However, if the type is passed into a generic function that is constrained on `ConnectionLike`, then the code will fail to compile because `Object` technically doesn't implement `ConnectionLike`, only `ConnectionWrapper` does.

The issue is that we have just such a generic function, and the orphan type rule only allows an `impl` for a third-party trait for `Object` to be made in the original crate. 

## Solution

Implement `redis::aio::ConnectionLike` for `deadpool::managed::Object`. The impl must be in the `deadpool` crate because that is where `Object` is defined; the orphan type rule prohibits implementing it in the `deadpool-redis` crate even though that is probably more the apt location given the naming (nor in our internal crates). (We also have an trait in an internal crate with a similar issue, but the orphan type rule permits us to provide that impl in the applicable internal crate.)

